### PR TITLE
Simplify mute/unmute

### DIFF
--- a/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
+++ b/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
@@ -1997,8 +1997,6 @@ void handlePostInputJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2006,9 +2004,10 @@ void handlePostInputJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostHpJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
 
@@ -2057,8 +2056,6 @@ void handlePostHpJson( AsyncWebServerRequest* request, uint8_t* data )
 {
   Serial.println( "POST /hp" );
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2066,9 +2063,10 @@ void handlePostHpJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostHpJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
 
@@ -2161,8 +2159,6 @@ void handlePostLshelvJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2170,9 +2166,10 @@ void handlePostLshelvJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostHpJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["idx"].as<String>() );
@@ -2268,8 +2265,6 @@ void handlePostPeqJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2277,10 +2272,10 @@ void handlePostPeqJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostPeqJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    delay(250);
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["idx"].as<String>() );
@@ -2375,8 +2370,6 @@ void handlePostHshelvJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2384,9 +2377,10 @@ void handlePostHshelvJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostHpJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["idx"].as<String>() );
@@ -2482,8 +2476,6 @@ void handlePostLpJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2491,9 +2483,10 @@ void handlePostLpJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostLpJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["idx"].as<String>() );
@@ -2591,8 +2584,6 @@ void handlePostPhaseJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2600,9 +2591,10 @@ void handlePostPhaseJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostPhaseJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["idx"].as<String>() );
@@ -2709,8 +2701,6 @@ void handlePostDelayJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2718,9 +2708,10 @@ void handlePostDelayJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostDelayJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["idx"].as<String>() );
@@ -2775,8 +2766,6 @@ void handlePostGainJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2784,9 +2773,10 @@ void handlePostGainJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostGainJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["idx"].as<String>() );
@@ -2842,8 +2832,6 @@ void handlePostXoJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -2851,9 +2839,10 @@ void handlePostXoJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostXoJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["idx"].as<String>() );
@@ -3015,8 +3004,6 @@ void handlePostFirJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -3024,9 +3011,10 @@ void handlePostFirJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostFirJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["idx"].as<String>() );
@@ -3111,8 +3099,6 @@ void handlePostPresetJson( AsyncWebServerRequest* request, uint8_t* data )
   if( haveDisplay )
     myDisplay.drawSwitchingPreset();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -3120,9 +3106,10 @@ void handlePostPresetJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostPresetJson(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   JsonObject root = jsonDoc.as<JsonObject>();
   Serial.println( root["pre"].as<String>() );
@@ -3365,8 +3352,6 @@ void handlePostAddonConfigJson( AsyncWebServerRequest* request, uint8_t* data )
   //  Serial.write(data[i]);
   //Serial.println();
 
-  softMuteDAC();
-
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
   if( err )
@@ -3374,9 +3359,10 @@ void handlePostAddonConfigJson( AsyncWebServerRequest* request, uint8_t* data )
     Serial.print( "[ERROR] handlePostAddonConfig(): Deserialization failed. " );
     Serial.println( err.c_str() );
     request->send( 400, "text/plain", err.c_str() );
-    softUnmuteDAC();
     return;
   }
+
+  softMuteDAC();
 
   if( Settings.addonid == ADDON_B )
   {

--- a/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
+++ b/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
@@ -1219,6 +1219,7 @@ void resetDAC( bool rst )
 void softMuteDAC( void )
 {
   AK4458_REGWRITE( AK4458_CONTROL2, 0b00100011 );
+  delay( 500 );
 }
 
 //==============================================================================
@@ -1997,7 +1998,6 @@ void handlePostInputJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -2058,7 +2058,6 @@ void handlePostHpJson( AsyncWebServerRequest* request, uint8_t* data )
   Serial.println( "POST /hp" );
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -2163,7 +2162,6 @@ void handlePostLshelvJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -2271,7 +2269,6 @@ void handlePostPeqJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -2379,7 +2376,6 @@ void handlePostHshelvJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -2487,7 +2483,6 @@ void handlePostLpJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -2597,7 +2592,6 @@ void handlePostPhaseJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -2716,7 +2710,6 @@ void handlePostDelayJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -2783,7 +2776,6 @@ void handlePostGainJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -2851,7 +2843,6 @@ void handlePostXoJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -3025,7 +3016,6 @@ void handlePostFirJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -3122,7 +3112,6 @@ void handlePostPresetJson( AsyncWebServerRequest* request, uint8_t* data )
     myDisplay.drawSwitchingPreset();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -3201,7 +3190,6 @@ void handlePostStore( AsyncWebServerRequest* request, uint8_t* data )
   Serial.println( "POST /store" );
 
   softMuteDAC();
-  delay(500);
 
   String fileName = presetUsrparamFile[currentPreset];
 
@@ -3378,7 +3366,6 @@ void handlePostAddonConfigJson( AsyncWebServerRequest* request, uint8_t* data )
   //Serial.println();
 
   softMuteDAC();
-  delay(500);
 
   DynamicJsonDocument jsonDoc(1024);
   DeserializationError err = deserializeJson( jsonDoc, (const char*)data );
@@ -3846,7 +3833,6 @@ void handleIrUpload( AsyncWebServerRequest* request, uint8_t* data, size_t len, 
   if( index + len >= total )
   {
     softMuteDAC();
-    delay(500);
 
     setFir( currentFirUploadIdx );
 
@@ -4478,7 +4464,6 @@ void loop()
         currentPreset = 0;
 
       softMuteDAC();
-      delay(500);
       initUserParams();
       uploadUserParams();
       updateAddOn();   
@@ -4509,7 +4494,6 @@ void loop()
         currentPreset--;
 
       softMuteDAC();
-      delay(500);
       initUserParams();
       uploadUserParams();
       updateAddOn();   
@@ -4551,7 +4535,6 @@ void loop()
         currentPreset--;
 
       softMuteDAC();
-      delay(500);
       initUserParams();
       uploadUserParams();
       updateAddOn();   
@@ -4568,7 +4551,6 @@ void loop()
         currentPreset = 0;
 
       softMuteDAC();
-      delay(500);
       initUserParams();
       uploadUserParams();
       updateAddOn();   


### PR DESCRIPTION
- Since delay is used (and required) after each mute, move the delay to `softMuteDAC()` and get rid of multiple occurences.
- Move muting after deserialization attempt, if it fails we don't have to unmute before returning.