### PR TITLE
Remove unused variables

### DIFF
--- a/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
+++ b/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
@@ -719,7 +719,6 @@ void uploadDspFirmware( void )
   uint32_t numBytesToRead = 0;
   byte byteReadMSB;
   byte byteReadLSB;
-  byte byteRead;
   uint16_t regaddr;
 
   if( fileDspProgram )
@@ -4385,7 +4384,6 @@ void setup()
         Update.printError(Serial);
     }
 
-    size_t written = 0;
     if( len > 0 )
     {
       if( Update.write( data, len ) != len )


### PR DESCRIPTION
Silent 2 compilation warnings:

```
SOURCES/WEBAPP/ESP32/aurora/aurora.ino: In function 'void uploadDspFirmware()':
SOURCES/WEBAPP/ESP32/aurora/aurora.ino:722:8: warning: unused variable 'byteRead' [-Wunused-variable]
   byte byteRead;
```

```
SOURCES/WEBAPP/ESP32/aurora/aurora.ino: In lambda function:
SOURCES/WEBAPP/ESP32/aurora/aurora.ino:4388:12: warning: unused variable 'written' [-Wunused-variable]
     size_t written = 0;
```
