### PR TITLE
Silent enumeration value 'kNumFilterDesigns' not handled in switch compilation error

### DIFF
--- a/SOURCES/WEBAPP/ESP32/aurora/AudioFilterFactory.cpp
+++ b/SOURCES/WEBAPP/ESP32/aurora/AudioFilterFactory.cpp
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <cmath>
 
 #include "AudioFilterFactory.h"
@@ -107,6 +108,10 @@ void AudioFilterFactory::makeHighPass( float a[], float b[], const int design, c
 
   switch( filterDesign )
   {
+  case kNumFilterDesigns:
+    /* this shouldn't occur */
+    assert(false);
+    break;
   case kBessel6:
     Omega = 2.0 * pi * fc / fs;
     a1 = pow( 2.7, -Omega ); 
@@ -611,6 +616,10 @@ void AudioFilterFactory::makeLowPass( float a[], float b[], const int design, co
 
   switch( filterDesign )
   {
+  case kNumFilterDesigns:
+    /* this shouldn't occur */
+    assert(false);
+    break;
   case kBessel6:
     Omega = 2.0 * pi * fc / fs;
     a1 = pow( 2.7, -Omega ); 


### PR DESCRIPTION
`kNumFilterDesigns` isn't meant to be a valid filter, but since it isn't tested in related `switch` blocks, compilation will fail if `-Werror=switch` is set.

Instead, test for kNumFilterDesigns and `assert(false)` if it happens, making compiler happy while catching this potential issue. Suggested by Archi.

Error messages look like:
`error: enumeration value 'kNumFilterDesigns' not handled in switch [-Werror=switch]`