### PR TITLE
Prevent loud noise on unmute via 250ms delay

### DIFF
--- a/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
+++ b/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
@@ -1320,6 +1320,7 @@ void softMuteDAC( void )
  */
 void softUnmuteDAC( void )
 {
+  delay( 250 );
   AK4458_REGWRITE( AK4458_CONTROL2, 0b00100010 );
 }
 


### PR DESCRIPTION
See issue #16, I have a loud noise when reconfiguring the DSP via the webinterface. This change prevents this.