### PR TITLE
Simplify preset number to string, reduce code redundancy

### DIFF
--- a/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
+++ b/SOURCES/WEBAPP/ESP32/aurora/aurora.ino
@@ -182,6 +182,9 @@ void uploadDspFirmware( void )
 /*! Updates the user interface on the display
  *
  */
+
+const char *presetLabels[MAX_NUM_PRESETS] = { "A", "B", "C", "D" };
+
 void updateUI( void )
 {
   if(haveDisplay)
@@ -194,24 +197,7 @@ void updateUI( void )
 
     if( (editMode == 0) || (editMode == 1) || (editMode == 2) )
     {
-      switch( currentPreset )
-      {
-      case 0:
-        myDisplay.drawUI( currentPlugInName.c_str(), ip.c_str(), "A", masterVolume.val, editMode );
-        break;
-      case 1:
-        myDisplay.drawUI( currentPlugInName.c_str(), ip.c_str(), "B", masterVolume.val, editMode );
-        break;
-      case 2:
-        myDisplay.drawUI( currentPlugInName.c_str(), ip.c_str(), "C", masterVolume.val, editMode );
-        break;
-      case 3:
-        myDisplay.drawUI( currentPlugInName.c_str(), ip.c_str(), "D", masterVolume.val, editMode );
-        break;
-      default:
-        myDisplay.drawUI( currentPlugInName.c_str(), ip.c_str(), "A", masterVolume.val, editMode );
-        break;
-      }
+      myDisplay.drawUI( currentPlugInName.c_str(), ip.c_str(), presetLabels[currentPreset], masterVolume.val, editMode );
     }
 
   }


### PR DESCRIPTION
- currentPreset is always in 0..MAX_NUM_PRESETS-1 range, so case default isn't needed
- since it starts at 0, it can be used as an array index
- if MAX_NUM_PRESETS is increased, the array will too, but the label will be a null string
- if MAX_NUM_PRESETS is decreased, the definition will error at compilation time